### PR TITLE
Switch to Polar BetterAuth integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.1.1",
         "@neondatabase/serverless": "^1.0.1",
-        "@polar-sh/nextjs": "^0.4.2",
+        "@polar-sh/better-auth": "^1.0.4",
         "@polar-sh/sdk": "^0.34.3",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -412,9 +412,7 @@
 
     "@pkgr/core": ["@pkgr/core@0.2.7", "", {}, "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg=="],
 
-    "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.2.1", "", { "dependencies": { "@polar-sh/sdk": "^0.34.2" } }, "sha512-qcfTi6es9j4DRodYoPN1w5OHlVIjmPuTwV8CF1B09ghwI3gkI0s2wyCK0anTafcOSK5/astCTCbvUbgtRdw6yg=="],
-
-    "@polar-sh/nextjs": ["@polar-sh/nextjs@0.4.2", "", { "dependencies": { "@polar-sh/adapter-utils": "0.2.1", "@polar-sh/sdk": "^0.34.2" }, "peerDependencies": { "next": "^15.0.0 || ^15.2.0-canary.*" } }, "sha512-9xhOGr2pZ0Sbg8LPlXKn8qhSKiIC0VvYFgTnHQd7Fgogyu146KAGMTqQkSADuNmdoWctHoeNxHDLGvMDiKZYOg=="],
+    "@polar-sh/better-auth": ["@polar-sh/better-auth@1.0.4", "", { "dependencies": { "zod": "^3.24.2" }, "peerDependencies": { "@polar-sh/sdk": "^0.32.15", "better-auth": "^1.2.7" } }, "sha512-sEuZtImh+kwEHqH5adOUPeEqqwrXbiVJ91BIeKdptD+1rdoXmtQSkazlnSWPA1LAo2xXe4Df/KQOaE1ByteuHw=="],
 
     "@polar-sh/sdk": ["@polar-sh/sdk@0.34.3", "", { "dependencies": { "standardwebhooks": "^1.0.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": ">=1.5.0 <1.10.0", "zod": ">= 3" }, "optionalPeers": ["@modelcontextprotocol/sdk"], "bin": { "mcp": "bin/mcp-server.js" } }, "sha512-D6887BO+ogK1idUVYJo2J5OvDKK8u+kzYNtUGfdfn2CiV24I8wgCyr/mUCMTJa1KZD2yhcUjgrxVUcufQABE6g=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"dependencies": {
 		"@hookform/resolvers": "^5.1.1",
 		"@neondatabase/serverless": "^1.0.1",
-		"@polar-sh/nextjs": "^0.4.2",
+		"@polar-sh/better-auth": "^1.0.4",
 		"@polar-sh/sdk": "^0.34.3",
 		"@radix-ui/react-dialog": "^1.1.14",
 		"@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,8 +1,0 @@
-import { Checkout } from "@polar-sh/nextjs";
-import { env } from "@/env";
-
-export const GET = Checkout({
-	accessToken: env.POLAR_ACCESS_TOKEN,
-	server: env.POLAR_MODE,
-	successUrl: "/confirmation",
-});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,8 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
+import { Polar } from "@polar-sh/sdk";
+import { polar, checkout, portal } from "@polar-sh/better-auth";
 import { db } from "@/db";
 import { env } from "./env.ts";
 
@@ -8,7 +10,23 @@ export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: "pg",
 	}),
-	plugins: [nextCookies()],
+	plugins: [
+		nextCookies(),
+		polar({
+			client: new Polar({
+				accessToken: env.POLAR_ACCESS_TOKEN,
+				server: env.POLAR_MODE,
+			}),
+			createCustomerOnSignUp: true,
+			use: [
+				checkout({
+					successUrl: "/confirmation",
+					authenticatedUsersOnly: true,
+				}),
+				portal(),
+			],
+		}),
+	],
 	socialProviders: {
 		google: {
 			clientId: env.GOOGLE_CLIENT_ID,

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,6 +1,7 @@
+"use client";
 import type { Product } from "@polar-sh/sdk/models/components/product.js";
-import Link from "next/link";
 import { useMemo } from "react";
+import { checkout } from "@/lib/auth-client";
 
 interface ProductCardProps {
 	product: Product;
@@ -37,12 +38,12 @@ export const ProductCard = ({ product }: ProductCardProps) => {
 				</ul>
 			</div>
 			<div className="flex flex-row gap-x-4 justify-between items-center">
-				<Link
+				<button
 					className="h-8 flex flex-row items-center justify-center rounded-full bg-white text-black font-medium px-4"
-					href={`/api/checkout?productId=${product.id}`}
+					onClick={() => checkout({ products: [product.id] })}
 				>
 					Buy
-				</Link>
+				</button>
 				<span className="text-neutral-500">{price}</span>
 			</div>
 		</div>

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,2 +1,7 @@
 import { createAuthClient } from "better-auth/react";
-export const { signIn, signUp, useSession } = createAuthClient({});
+import { polarClient } from "@polar-sh/better-auth";
+
+export const { signIn, signUp, useSession, checkout, customer } =
+	createAuthClient({
+		plugins: [polarClient()],
+	});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,8 +37,9 @@
 	--animate-accordion-down: accordion-down 0.2s ease-out;
 	--animate-accordion-up: accordion-up 0.2s ease-out;
 
-	--font-sans: var(--font-sans), ui-sans-serif, system-ui, sans-serif,
-		"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	--font-sans:
+		var(--font-sans), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+		"Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
 	@keyframes accordion-down {
 		from {


### PR DESCRIPTION
## Summary
- drop `@polar-sh/nextjs`
- add `@polar-sh/better-auth`
- configure Polar BetterAuth plugin in the auth server
- expose Polar client functions to the React auth client
- update `ProductCard` to trigger BetterAuth checkout
- remove old Next.js checkout API route

## Testing
- `bun run format`
- `npx tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_686faf01e94483308ea56bf63e6a0f75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication and checkout experience by integrating the Polar SDK and better-auth plugin, enabling direct checkout and customer management features.

* **Bug Fixes**
  * Improved checkout initiation by replacing navigation-based checkout with a direct function call from the product card.

* **Chores**
  * Updated dependencies to use the latest authentication package.
  * Reformatted CSS for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->